### PR TITLE
minor refactor

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -30,7 +30,7 @@ var searchCmd = &cobra.Command{
 Example: ./go-getter-fdc search onion`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Search called for %v...\n", args)
-		s := client.GetFoodsList(args)
+		s := client.FoodsSearch(args)
 		fmt.Printf("%s", s)
 	},
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,10 +10,12 @@ import (
 	"strings"
 )
 
-var foodUrl, _ = url.Parse("https://api.nal.usda.gov/fdc/v1")
-var apiKey string
+var (
+	foodUrl, _ = url.Parse("https://api.nal.usda.gov/fdc/v1")
+	apiKey string
+)
 
-func GetFoodsList(keywords []string) string {
+func FoodsSearch(keywords []string) string {
 	apiKeyCheck()
 	apiKey = os.Getenv("API_KEY")
 	foodUrl.Path += "/foods/search"


### PR DESCRIPTION
Call the exported method by a more accurate name since there is an endpoint named `foods/list` that I will likely query later.