### PR TITLE
Fix query builder bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Simple CLI tool that retrieves food data from USDA's FoodData Central API
 
 https://fdc.nal.usda.gov/api-guide.html
 
+You will need an API key from FDC to use this app: https://fdc.nal.usda.gov/api-key-signup.html
+
 ## Building
 `go build`
 
@@ -11,4 +13,4 @@ https://fdc.nal.usda.gov/api-guide.html
 
 ## Usage
 Search for food by keywords:
-`./go-getter-fdc search cheddar cheese`
+`API_KEY=yourKey ./go-getter-fdc search cheddar cheese`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -79,8 +79,7 @@ func buildSearchString(keywords []string) string {
 	} else {
 		for i := 0; i < len(keywords); i++ {
 			if i != (len(keywords) - 1) {
-				stringWithSpace := fmt.Sprintf("%s ", keywords[i])
-				builder.WriteString(stringWithSpace)
+				builder.WriteString(fmt.Sprintf("%s ", keywords[i]))
 			} else {
 				builder.WriteString(keywords[i])
 			}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,3 +1,18 @@
+/*
+Copyright © 2020 Greg Whorley <greg@whorley.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package client
 
 import (
@@ -17,7 +32,6 @@ var (
 
 func FoodsSearch(keywords []string) string {
 	apiKeyCheck()
-	apiKey = os.Getenv("API_KEY")
 	foodUrl.Path += "/foods/search"
 	params := url.Values{}
 	params.Add("api_key", apiKey)
@@ -53,6 +67,8 @@ func apiKeyCheck() {
 	_, exists := os.LookupEnv("API_KEY")
 	if !exists {
 		log.Fatal("API_KEY not set! Cancelling search...\n")
+	} else {
+		apiKey = os.Getenv("API_KEY")
 	}
 }
 
@@ -63,7 +79,7 @@ func buildSearchString(keywords []string) string {
 	} else {
 		for i := 0; i < len(keywords); i++ {
 			if i != (len(keywords) - 1) {
-				stringWithSpace := fmt.Sprintf("%s ")
+				stringWithSpace := fmt.Sprintf("%s ", keywords[i])
 				builder.WriteString(stringWithSpace)
 			} else {
 				builder.WriteString(keywords[i])


### PR DESCRIPTION
Missed an arg in string builder writeString() call. Added license verbiage in client.go. Updated README with api key info.