### PR TITLE
Add CLI flags to make some query params configurable by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@ You will need an API key from FDC to use this app: https://fdc.nal.usda.gov/api-
 `go test -v`
 
 ## Usage
-Search for food by keywords:
+Run `./go-getter-fdc search --help` for example usage and valid flags. Your FDC API key must either
+be exported or passed into the command line as an `API_KEY` environment variable.
+
+Example command to search for food by keywords:
 `API_KEY=yourKey ./go-getter-fdc search cheddar cheese`

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -22,7 +22,8 @@ import (
 )
 
 // searchCmd represents the search command
-var searchCmd = &cobra.Command{
+var (
+	searchCmd = &cobra.Command{
 	Use:   "search",
 	Short: "Search for foods by keywords",
 	Long: `This action and subsequent arguments are passed in to the FoodData Central API 
@@ -30,7 +31,8 @@ var searchCmd = &cobra.Command{
 Example: ./go-getter-fdc search onion`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Search called for %v...\n", args)
-		foodsSearch := client.FoodsSearch(args)
+		// TODO collect all flag values and pass one thing into FoodsSearch()
+		foodsSearch := client.FoodsSearch(args, pageSize, dataType, requireAllWords)
 		for _, food := range foodsSearch.Foods {
 			fmt.Printf("Basic Data:\n")
 			fmt.Printf("  Description: %v\n", food.Description)
@@ -44,6 +46,10 @@ Example: ./go-getter-fdc search onion`,
 		}
 	},
 }
+	pageSize string
+	dataType string
+	requireAllWords string
+)
 
 func init() {
 	rootCmd.AddCommand(searchCmd)
@@ -56,5 +62,7 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// searchCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	searchCmd.Flags().StringVar(&pageSize,"page-size", "1", "Set the page size for the result set. Defaults to 1.")
+	searchCmd.Flags().StringVar(&dataType, "datatype", "Foundation", "Set the datatype to one of the following:\nFoundation\nBranded\nSurvey\nLegacy")
+	searchCmd.Flags().StringVar(&requireAllWords, "require-all-words", "true", "Require all keywords in search results. Defaults to true.")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,16 +32,15 @@ var (
 	foodResults FoodsSearchJson
 )
 
-func FoodsSearch(keywords []string) FoodsSearchJson {
+func FoodsSearch(keywords []string, pageSize string, dataType string, requireAllWords string) FoodsSearchJson {
 	apiKeyCheck()
 	foodUrl.Path += "/foods/search"
 	params := url.Values{}
 	params.Add("api_key", apiKey)
 	params.Add("query", buildSearchString(keywords))
-	// TODO: make these params configurable
-	params.Add("pageSize", "1")
-	params.Add("dataType", "Foundation")
-	params.Add("requireAllWords", "true")
+	params.Add("pageSize", pageSize)
+	params.Add("dataType", dataType)
+	params.Add("requireAllWords", requireAllWords)
 	foodUrl.RawQuery = params.Encode()
 	resp, respErr := http.Get(foodUrl.String())
 	if respErr != nil {


### PR DESCRIPTION
Trying out cobra's CLI flag support. Added flags for some query parameters I've been meaning to make configurable. I added a TODO for compiling any and all flag values into one object that will be passed into the food search function.