### PR TITLE
add regexp filter for trash nutrient data

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/gregwhorley/go-getter-fdc/pkg/client"
 	"github.com/spf13/cobra"
+	"regexp"
 )
 
 // searchCmd represents the search command
@@ -33,15 +34,20 @@ Example: ./go-getter-fdc search onion`,
 		fmt.Printf("Search called for %v...\n", args)
 		queryOptions = client.QueryOptionsFiller(pageSize, dataType, requireAllWords)
 		foodsSearch := client.FoodsSearch(args, queryOptions)
+		// TODO: open a browser window and display food data
 		for _, food := range foodsSearch.Foods {
 			fmt.Printf("Basic Data:\n")
 			fmt.Printf("  Description: %v\n", food.Description)
 			fmt.Printf("  Data Type: %v\n", food.DataType)
-			fmt.Printf("  Ingredients: %v\n", food.Ingredients)
+			if food.Ingredients != "" {
+				fmt.Printf("  Ingredients: %v\n", food.Ingredients)
+			}
 			fmt.Printf("Nutrient Data:\n")
 			for _, nutrients := range food.FoodNutrients {
-				fmt.Printf("  Name: %v\n", nutrients.NutrientName)
-				fmt.Printf("  Amount: %v%v\n", nutrients.NutrientNumber, nutrients.UnitName)
+				if matched, _ := regexp.Match(`[\d]:[\d]`, []byte(nutrients.NutrientName)) ; !matched {
+					fmt.Printf("  Name: %v\n", nutrients.NutrientName)
+					fmt.Printf("  Amount: %v%v\n", nutrients.NutrientNumber, nutrients.UnitName)
+				}
 			}
 		}
 	},
@@ -63,7 +69,7 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	searchCmd.Flags().StringVar(&pageSize,"page-size", "1", "Set the page size for the result set. Defaults to 1.")
+	searchCmd.Flags().StringVar(&pageSize,"page-size", "1", "Set the page size for the result set.")
 	searchCmd.Flags().StringVar(&dataType, "datatype", "Foundation", "Set the datatype to one of the following:\nFoundation\nBranded\nSurvey\nLegacy")
-	searchCmd.Flags().StringVar(&requireAllWords, "require-all-words", "true", "Require all keywords in search results. Defaults to true.")
+	searchCmd.Flags().StringVar(&requireAllWords, "require-all-words", "true", "Require all keywords in search results.")
 }

--- a/pkg/client/foods_search.go
+++ b/pkg/client/foods_search.go
@@ -47,7 +47,6 @@ func FoodsSearch(keywords []string, queryOptions map[string]string) FoodsSearchJ
 		log.Fatal("Expected HTTP 200 but received ", resp.StatusCode)
 	}
 	defer resp.Body.Close()
-	// TODO: I want to omit nutrient data with names like "int:int"
 	body, readErr := ioutil.ReadAll(resp.Body)
 	if readErr != nil {
 		log.Fatal(readErr)


### PR DESCRIPTION
Add regexp match for the nutrient data entries that look like "number:number" so they can be omitted from the printed results. Changed a couple of help messages since the default is printed by default.